### PR TITLE
Handling unsigned int rollover

### DIFF
--- a/emu2influx.py
+++ b/emu2influx.py
@@ -119,4 +119,11 @@ if __name__ == '__main__':
     influx = InfluxDBClient(database=args.db, host=args.host, port=args.port, username=args.username,
                             password=args.password)
     influx.create_database(args.db)
-    main(client=emu(args.serial_port), db=influx)
+    
+    try:
+        main(client=emu(args.serial_port), db=influx)
+    except KeyboardInterrupt:
+        try:
+                sys.exit(0)
+        except SystemExit:
+                os._exit(0)

--- a/emu2influx.py
+++ b/emu2influx.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+import os 
 from datetime import datetime
 
 from influxdb import InfluxDBClient

--- a/emu2influx.py
+++ b/emu2influx.py
@@ -6,14 +6,19 @@ from influxdb import InfluxDBClient
 from emu import *
 
 Y2K = 946684800
+int_max = 2**31-1
+uint_max = 2**32-1
 
 
 def get_timestamp(obj):
     return datetime.utcfromtimestamp(Y2K + int(obj.TimeStamp, 16)).isoformat()
 
-
 def get_reading(reading, obj):
-    return int(reading, 16) * int(obj.Multiplier, 16) / float(int(obj.Divisor, 16))
+    reading = int(reading, 16) * int(obj.Multiplier, 16)
+    if reading > int_max:
+        reading = -1 * (uint_max - reading)
+    return reading / float(int(obj.Divisor, 16))
+
 
 
 def get_price(obj):


### PR DESCRIPTION
The EMU2 does not correctly report negative readings (e.g. solar panels generating more than demand)  - it appears to be using an unsigned int which rolls over.