### PR TITLE
Emit CurrentSummationReceived as another field in the "reading" metric

### DIFF
--- a/emu2influx.py
+++ b/emu2influx.py
@@ -93,7 +93,9 @@ def main(client, db):
                         "time": timestamp,
                         "fields": {
                             "reading": get_reading(current_summation_delivered.SummationDelivered,
-                                                   current_summation_delivered)
+                                                   current_summation_delivered),
+                            "reading_received": get_reading(current_summation_delivered.SummationReceived,
+                                                            current_summation_delivered)
                         }
                     }
                 ]


### PR DESCRIPTION
The "CurrentSummationDelivered" command actually returns two values:

* `SummationDelivered` - what is currently reported as the `reading` metric. I understand this to be energy delivered from the utility to the meter.
* `SummationReceived` - energy _received_ by the meter, e.g. from a solar array when using net metering.

This adds an additional `reading_received` field to the `reading` metric in InfluxDB, so you can calculate how much energy you are providing back to the utility.